### PR TITLE
RN app fails to start if there are no initial posts

### DIFF
--- a/RNApp/app/index.js
+++ b/RNApp/app/index.js
@@ -51,7 +51,7 @@ export default React.createClass({
 
   makeSubscription() {
     ddpClient.subscribe("posts", [], () => {
-      this.setState({posts: ddpClient.collections.posts});
+      this.setState({posts: ddpClient.collections.posts || {} });
     });
   },
 


### PR DESCRIPTION
Sets state.posts to an empty object so count inits to 0
